### PR TITLE
feat: improved functionality of auxiliary scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,75 @@
-# Yarrowia_lipolytica_W29-GEM
+### Yarrowia_lipolytica_W29-GEM: Genome-scale model of _Yarrowia lipolytica_
 
-- Brief Model Description
+### Description
 
-This repository contains the current genome-scale metabolic model of _Yarrowia lipolytica_ W29, named **iYali4**. Various different updated versions can be downloaded as [releases](https://github.com/SysBioChalmers/Yarrowia_lipolytica_W29-GEM/releases).
+This repository contains the current genome-scale metabolic model **iYali** for the oleaginous yeast _Yarrowia lipolytica_ W29, among others a promising microbial cell factory for the production of oleochemicals and various other products.
 
-- Abstract
+### Citation
 
-_Yarrowia lipolytica_ is a promising microbial cell factory for the production of lipids to be used as fuels and chemicals, but there are few studies on regulation of its metabolism. Here we performed the first integrated data analysis of _Y. lipolytica_ grown in carbon and nitrogen limited chemostat cultures. We first reconstructed a genome-scale metabolic model and used this for integrative analysis of multilevel omics data. Metabolite profiling and lipidomics was used to quantify the cellular physiology, while regulatory changes were measured using RNAseq. Analysis of the data showed that lipid accumulation in _Y. lipolytica_ does not involve transcriptional regulation of lipid metabolism but is associated with regulation of amino-acid biosynthesis, resulting in redirection of carbon flux during nitrogen limitation from amino acids to lipids. Lipid accumulation in _Y. lipolytica_ at nitrogen limitation is similar to the overflow metabolism observed in many other microorganisms, e.g. ethanol production by Sacchromyces cerevisiae at nitrogen limitation.
+>Kerkhoven EJ, Pomraning KR, Baker SE, Nielsen J (2016) "Regulation of amino-acid metabolism controls flux to lipid accumulation in _Yarrowia lipolytica_." npj Systems Biology and Applications 2:16005. doi:[10.1038/npjsba.2016.5](http://www.nature.com/articles/npjsba20165) / pubmed:[28725468](https://pubmed.ncbi.nlm.nih.gov/28725468/)
 
-- Model KeyWords
+The iYali model distributed on this GitHub repository is continuously updated, with the latest releases available [here](https://github.com/SysBioChalmers/Yarrowia_lipolytica_W29-GEM/releases). To get access to the model associated to the Kerkhoven _et al_. (2016) publication, use [iYali release 4.0.0](https://github.com/SysBioChalmers/Yarrowia_lipolytica_W29-GEM/releases/tag/4.0.0).
 
-**GEM Category:** Species; **Utilisation:** experimental data reconstruction; **Field:** metabolic-network reconstruction; **Type of Model:** curated; **Model Source:** [YeastMetabolicNetwork](https://github.com/SysBioChalmers/yeast-metabolic-network-7.6); **Omic Source:** [Transcriptomics](http://www.ebi.ac.uk/arrayexpress/experiments/E-MTAB-5284/), [Proteomics](https://doi.org/10.6084/m9.figshare.4990394.v1), [Metabolomics](https://doi.org/10.6084/m9.figshare.4990394.v1); **Taxonomy:** Yarrowia lipolytica W29; **Metabolic System:** General Metabolism; **Bioreactor**; **Strain:** W29; **Condition:** Minimal medium;
+### Keywords
 
-- Reference:  
->Kerkhoven EJ, Pomraning KR, Baker SE, Nielsen J (2016) "Regulation of amino-acid metabolism controls flux to lipid accumulation in _Yarrowia lipolytica_." npj Systems Biology and Applications 2:16005. doi:[10.1038/npjsba.2016.5](http://www.nature.com/articles/npjsba20165)
+**Utilisation:** Experimental data reconstruction; Predictive simulation
+**Field:** Metabolic-network reconstruction
+**Type of Model:** Curated reconstruction
+**Model Source:** [yeast-GEM](https://github.com/SysBioChalmers/yeast-GEM)
+**Omic Source:** [Transcriptomics](http://www.ebi.ac.uk/arrayexpress/experiments/E-MTAB-5284/), [Proteomics](https://doi.org/10.6084/m9.figshare.4990394.v1), [Metabolomics](https://doi.org/10.6084/m9.figshare.4990394.v1)
+**Taxonomic name:** Yarrowia lipolytica W29
+**Taxonomic ID:** [taxonomy:100226](https://identifiers.org/taxonomy:4952)
+**Metabolic System:** General Metabolism
+**Strain:** W29
+**Condition:** Minimal medium
 
-- Pubmed ID: 28725468
+### Model Overview
 
-- Last update: 2017-10-24
+| Taxonomy | Latest change | Version | Reactions | Metabolites | Genes |
+| ------------- |:-------------:|:-------------:|:-------------:|:-------------:|:-----:|
+| _Yarrowia lipolytica_ W29 | 04-Apr-2021 | 4.1.2 | 2599 | 2065 | 1775 |
 
-- The model:
+## Installation & Usage
 
-|Taxonomy | Template Model | Reactions | Metabolites| Genes |
-| ------------- |:-------------:|:-------------:|:-------------:|-----:|
-|Yarrowia lipolytica W29 |	YeastMetabolicNetwork 7.6| 1942|	1691|	847|
+### **User:**
 
+To obtain iYali, clone it from [`master`](https://github.com/sysbiochalmers/Yarrowia_lipolytica_W29-GEM) in the GitHub repository, or just download the [latest release](https://github.com/sysbiochalmers/Yarrowia_lipolytica_W29-GEM/releases).
 
-This repository is administered by [@edkerk](https://github.com/edkerk/), Division of Systems and Synthetic Biology, Department of Biology and Biological Engineering, Chalmers University of Technology
+iYali is distributed in SBML L3V1 FBCv1 format (`model/iYali.xml`), and therefore works well with any appropriate constraint-based modelling package, such as [RAVEN Toolbox](https://github.com/sysbiochalmers/raven/), [cobrapy](https://github.com/opencobra/cobrapy),  and [COBRA Toolbox](https://github.com/opencobra/cobratoolbox). Installation instructions for each package are provided on their website, after which you can use their default functions for loading and exporting of the models:
 
+***RAVEN Toolbox***
+```matlab
+model = importModel('iYali.xml')
+exportModel(model, 'iYali.xml')
+```
 
-## Installation
+***cobrapy***
+```python
+import cobra
+model = cobra.io.read_sbml_model('iYali.xml')
+cobra.io.write_sbml_model(model, 'iYali.xml')
+```
 
-### Required Software
+***COBRA Toolbox*** \*
+```matlab
+model = readCbModel('iYali.xml')
+writeCbModel(model, 'iYali.xml')
+```
+\* note that some annotation might be lost when exporting the model from COBRA Toolbox.
 
-  * This model is recommended to be used with the [**RAVEN toolbox for MATLAB**](https://github.com/SysBioChalmers/RAVEN) (version 2.0).
-  * Alternatively, the model can also be directly used with the [COBRA toolbox for MATLAB](https://github.com/opencobra/cobratoolbox).
+### **Contributor:**
 
-### Dependencies - Recommended Software
-* Please see the [RAVEN toolbox](https://github.com/SysBioChalmers/RAVEN) repository for dependencies regarding RAVEN.
+Development of the model is done via RAVEN, to ensure that model content is retained as much as possible (I/O through other software might result in undesired loss of annotation).
 
-### Installation Instructions
-* Clone [master](https://github.com/SysBioChalmers/Yarrowia_lipolytica_W29-GEM) branch from [SysBioChalmers GitHub](https://github.com/SysBioChalmers/Yarrowia_lipolytica_W29-GEM).
+[Fork](https://github.com/sysbiochalmers/Yarrowia_lipolytica_W29-GEM/fork) the iYali repository to your own GitHub account, and create a new branch from `devel`.
+
+Load the model in MATLAB using the default code specified [above](#user). Before making a pull-request to the `devel` branch, export the model with the `newCommit` function provided in the repository:
+```matlab
+cd ./code
+newCommit(model);
+```
+
+More information on contributing to iYali can be found in the [contributing guidelines](.github/CONTRIBUTING.md), read these to get started. Contributions are always welcome!
+
+### Contributors
+* [Eduard J. Kerkhoven](https://www.chalmers.se/en/staff/Pages/Eduard-Kerkhoven.aspx) ([@edkerk](https://github.com/edkerk)), Chalmers University of Technology, Sweden

--- a/code/getEarlierModel.m
+++ b/code/getEarlierModel.m
@@ -1,0 +1,50 @@
+function model = getEarlierModel(version)
+% getEarlierModel
+%   Obtain an earlier model version from the Git repository. If no output
+%   is specified, it will keep the file as _earlierModel.xml in the current
+%   directory, otherwise it will return the model as loaded by importModel.
+%
+%   Input:
+%   version     string of either 'master' for latest release, or e.g. 
+%               '4.1.2' for a specific release.
+%
+%   Output:
+%   model       model structure from obtained model (opt)
+%
+%   Usage: model = getEarlierModel(version)
+
+nargoutchk(0,1)
+
+if strcmp(version,'master')
+    status=system('git show master:model/iYali.xml > _earlierModel.xml')
+    if status~=0
+        disp('Trying legacy ''ModelFiles/xml/iYali.xml'' instead.')
+        status=system('git show master:ModelFiles/xml/iYali.xml > _earlierModel.xml')
+        if status~=0
+            delete('./_earlierModel.xml')
+            error('Failed to obtain the desired model version.');
+        end
+    end
+elseif regexp(version,'^\d+\.\d+\.\d+$')
+    tagpath = ['refs/tags/' version ':model/iYali.xml'];
+    status=system(['git show ' tagpath ' > _earlierModel.xml']);
+    if status~=0
+        disp('Trying legacy ''ModelFiles/xml/iYali.xml'' instead.')
+        tagpath = ['refs/tags/' version ':ModelFiles/xml/iYali.xml'];
+        status=system(['git show ' tagpath ' > _earlierModel.xml']);
+        if status~=0
+            delete('./_earlierModel.xml')
+            error('Failed to obtain the desired model version.');
+        end
+    end
+else
+    error('''version'' should be either ''master'' or of the format ''4.1.2''.')
+end
+switch nargout
+    case 0
+        disp('Earlier model version is stored as ''_earlierModel.xml'' in the current working directory')   
+    case 1
+        disp('Loading earlier model version.')
+        model=importModel('_earlierModel.xml');
+        delete('_earlierModel.xml');
+end

--- a/code/newRelease.m
+++ b/code/newRelease.m
@@ -46,6 +46,9 @@ model = importModel('../model/iYali.xml');
 
 %Include tag and save model:
 model.description = ['v' newVersion];
+nGenes=num2str(numel(model.genes));
+nMets=num2str(numel(model.mets));
+nRxns=num2str(numel(model.rxns));
 
 %Save model
 exportForGit(model,'iYali','../model/',{'mat', 'txt', 'xlsx', 'xml', 'yml'},true,false);
@@ -54,5 +57,17 @@ exportForGit(model,'iYali','../model/',{'mat', 'txt', 'xlsx', 'xml', 'yml'},true
 fid = fopen('../version.txt','wt');
 fprintf(fid,newVersion);
 fclose(fid);
-end
 
+%Update model stats in README.md
+newStats = ['$1 ' datestr(now,'dd-mmm-yyyy') ' | ' newVersion ' | ' nRxns ' | ' nMets ' | ' nGenes ' |'];
+searchStats = '^(\| \_Yarrowia lipolytica_ W29 \| )\d{2}-\D{3}-\d{4} \| \d+\.\d+\.\d+ \| \d+ \| \d+ \| \d+ \|';
+fOld = fopen('../README.md','rt');
+fNew = fopen('../README.new','w+');
+while ~feof(fOld)
+    str = fgets(fOld)
+    fwrite(fNew,regexprep(str,searchStats,newStats))
+end
+fclose(fNew);
+fclose(fOld);
+movefile '../README.new' '../README.md' f
+end


### PR DESCRIPTION
- Feature:
  - `newRelease` will now modify `README.md` with the new model stats, date and version number.
  - new fuction `getEarlierModel` can easily obtain earlier versions of the model, to be used in curation scripts.
- Documentation:
  - `README.md` modified to agree to [`standard-GEM`](https://github.com/MetabolicAtlas/standard-GEM), plus mention of latest model change and release version number.

`Model Overview` in `README.md` should be removed before `devel` is merged with `master`, as these stats should not be included in that file in `devel`, but is kept for now for testing `newRelease` functionality.