### PR TITLE
chore: rename master to main across the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The iYali model distributed on this GitHub repository is continuously updated, w
 
 ### **User:**
 
-To obtain iYali, clone it from [`master`](https://github.com/sysbiochalmers/Yarrowia_lipolytica_W29-GEM) in the GitHub repository, or just download the [latest release](https://github.com/sysbiochalmers/Yarrowia_lipolytica_W29-GEM/releases).
+To obtain iYali, clone it from [`main`](https://github.com/sysbiochalmers/Yarrowia_lipolytica_W29-GEM) in the GitHub repository, or just download the [latest release](https://github.com/sysbiochalmers/Yarrowia_lipolytica_W29-GEM/releases).
 
 iYali is distributed in SBML L3V1 FBCv1 format (`model/iYali.xml`), and therefore works well with any appropriate constraint-based modelling package, such as [RAVEN Toolbox](https://github.com/sysbiochalmers/raven/), [cobrapy](https://github.com/opencobra/cobrapy),  and [COBRA Toolbox](https://github.com/opencobra/cobratoolbox). Installation instructions for each package are provided on their website, after which you can use their default functions for loading and exporting of the models:
 

--- a/code/getEarlierModel.m
+++ b/code/getEarlierModel.m
@@ -5,7 +5,7 @@ function model = getEarlierModel(version,unversion)
 %   directory, otherwise it will return the model as loaded by importModel.
 %
 %   Input:
-%   version     string of either 'master' for latest release, or e.g. 
+%   version     string of either 'main' for latest release, or e.g. 
 %               '4.1.2' for a specific release.
 %   unversion   logical whether version information should be stripped from
 %               the model (opt, default false, only applies if output is
@@ -21,11 +21,11 @@ if nargin<2
     unversion = false;
 end
 
-if strcmp(version,'master')
-    status=system('git show master:model/iYali.xml > _earlierModel.xml')
+if strcmp(version,'main')
+    status=system('git show main:model/iYali.xml > _earlierModel.xml')
     if status~=0
         disp('Trying legacy ''ModelFiles/xml/iYali.xml'' instead.')
-        status=system('git show master:ModelFiles/xml/iYali.xml > _earlierModel.xml')
+        status=system('git show main:ModelFiles/xml/iYali.xml > _earlierModel.xml')
         if status~=0
             delete('./_earlierModel.xml')
             error('Failed to obtain the desired model version.');
@@ -44,7 +44,7 @@ elseif regexp(version,'^\d+\.\d+\.\d+$')
         end
     end
 else
-    error('''version'' should be either ''master'' or of the format ''4.1.2''.')
+    error('''version'' should be either ''main'' or of the format ''4.1.2''.')
 end
 switch nargout
     case 0

--- a/code/newCommit.m
+++ b/code/newCommit.m
@@ -10,10 +10,10 @@ function newCommit(model)
 %           prior to exporting other files
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%Check if in master:
+%Check if in main:
 currentBranch = git('rev-parse --abbrev-ref HEAD');
-if strcmp(currentBranch,'master')
-    error('ERROR: in master branch. For new releases, use newRelease.m')
+if strcmp(currentBranch,'main')
+    error('ERROR: in main branch. For new releases, use newRelease.m')
 end
 
 if ~exist('model')

--- a/code/newRelease.m
+++ b/code/newRelease.m
@@ -6,10 +6,10 @@ function newRelease(bumpType)
 %   bumpType    string specifying the type of release, either 'major',
 %               'minor' or 'patch'
 
-%Check if in master:
+%Check if in main:
 currentBranch = git('rev-parse --abbrev-ref HEAD');
-if ~strcmp(currentBranch,'master')
-    error('ERROR: not in master')
+if ~strcmp(currentBranch,'main')
+    error('ERROR: not in main')
 end
 
 %Bump version number:


### PR DESCRIPTION
This PR aims to replace all occurrences of `master` to `main` across the repository.